### PR TITLE
Made the background image into a variable

### DIFF
--- a/themes/ClearVision_Amber.theme.css
+++ b/themes/ClearVision_Amber.theme.css
@@ -24,6 +24,7 @@ RemoveShadows theme: https://git.io/v6MuU IMPORTANT: Activate on top of a ClearV
 :root {
 	--main-color: #e67a27;
 	--hover-color: #b35d1e;
+	--background-image: url("https://github.com/Zerthox/ClearVision/raw/master/images/amber.jpg");
 }
 /*
 --------------------------------------------------------------------------------------------------------------------------------------------
@@ -42,7 +43,7 @@ body::after,
 .invite-modal .invite-splash,
 .radio-theme.light label,
 .radio-theme.dark label{
-    background-image: url(https://github.com/Zerthox/ClearVision/raw/master/images/amber.jpg) !important; /* IMPORTANT: Link must be HTTPS! */
+    background-image: var(--background-image) !important; /* IMPORTANT: Link must be HTTPS! */
 }
 /*
 --------------------------------------------------------------------------------------------------------------------------------------------

--- a/themes/ClearVision_Amethyst.theme.css
+++ b/themes/ClearVision_Amethyst.theme.css
@@ -24,6 +24,7 @@ RemoveShadows theme: https://git.io/v6MuU IMPORTANT: Activate on top of a ClearV
 :root {
 	--main-color: #da27e6;
 	--hover-color: #a71eb3;
+	--background-image: url("https://github.com/Zerthox/ClearVision/raw/master/images/amethyst.jpg");
 }
 /*
 --------------------------------------------------------------------------------------------------------------------------------------------
@@ -42,7 +43,7 @@ body::after,
 .invite-modal .invite-splash,
 .radio-theme.light label,
 .radio-theme.dark label{
-    background-image: url(https://github.com/Zerthox/ClearVision/raw/master/images/amethyst.jpg) !important; /* IMPORTANT: Link must be HTTPS! */
+    background-image: var(--background-image) !important; /* IMPORTANT: Link must be HTTPS! */
 }
 /*
 --------------------------------------------------------------------------------------------------------------------------------------------

--- a/themes/ClearVision_Emerald.theme.css
+++ b/themes/ClearVision_Emerald.theme.css
@@ -24,6 +24,7 @@ RemoveShadows theme: https://git.io/v6MuU IMPORTANT: Activate on top of a ClearV
 :root {
 	--main-color: #33e627;
 	--hover-color: #2ab31e;
+	--background-image: url("https://github.com/Zerthox/ClearVision/raw/master/images/emerald.jpg");
 }
 /*
 --------------------------------------------------------------------------------------------------------------------------------------------
@@ -42,7 +43,7 @@ body::after,
 .invite-modal .invite-splash,
 .radio-theme.light label,
 .radio-theme.dark label{
-    background-image: url(https://github.com/Zerthox/ClearVision/raw/master/images/emerald.jpg) !important; /* IMPORTANT: Link must be HTTPS! */
+    background-image: var(--background-image) !important; /* IMPORTANT: Link must be HTTPS! */
 }
 /*
 --------------------------------------------------------------------------------------------------------------------------------------------

--- a/themes/ClearVision_Ruby.theme.css
+++ b/themes/ClearVision_Ruby.theme.css
@@ -24,6 +24,7 @@ RemoveShadows theme: https://git.io/v6MuU IMPORTANT: Activate on top of a ClearV
 :root {
 	--main-color: #e62727;
 	--hover-color: #b31e1e;
+	--background-image: url("https://github.com/Zerthox/ClearVision/raw/master/images/ruby.jpg");
 }
 /*
 --------------------------------------------------------------------------------------------------------------------------------------------
@@ -42,7 +43,7 @@ body::after,
 .invite-modal .invite-splash,
 .radio-theme.light label,
 .radio-theme.dark label{
-    background-image: url(https://github.com/Zerthox/ClearVision/raw/master/images/ruby.jpg) !important; /* IMPORTANT: Link must be HTTPS! */
+    background-image: var(--background-image) !important; /* IMPORTANT: Link must be HTTPS! */
 }
 /*
 --------------------------------------------------------------------------------------------------------------------------------------------

--- a/themes/ClearVision_Sapphire.theme.css
+++ b/themes/ClearVision_Sapphire.theme.css
@@ -24,6 +24,7 @@ RemoveShadows theme: https://git.io/v6MuU IMPORTANT: Activate on top of a ClearV
 :root {
 	--main-color: #2780e6;
 	--hover-color: #1e63b3;
+	--background-image: url("https://github.com/Zerthox/ClearVision/raw/master/images/sapphire.jpg");
 }
 /*
 --------------------------------------------------------------------------------------------------------------------------------------------
@@ -42,7 +43,7 @@ body::after,
 .invite-modal .invite-splash,
 .radio-theme.light label,
 .radio-theme.dark label{
-    background-image: url(https://github.com/Zerthox/ClearVision/raw/master/images/sapphire.jpg) !important; /* IMPORTANT: Link must be HTTPS! */
+    background-image: var(--background-image) !important; /* IMPORTANT: Link must be HTTPS! */
 }
 /*
 --------------------------------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
Yo. So the idea here was that you could set the background variable using the Theme Picker plugin, which would make it easier for some people than css. Ofc, this would also mean that you could reduce the number of lines in the `variation.theme.css` files by moving the background setting css to the main css file, but I'm lazy. For maximum ease of use, an edit to the Theme Picker plugin that checks for variables starting with `url("` and then cuts out the `url("` at the start and the `")` at the end would be needed, but it can wait xD