### PR TITLE
I unscrewed it.

### DIFF
--- a/mods/ContrastImprovements.css
+++ b/mods/ContrastImprovements.css
@@ -1,21 +1,21 @@
-/* Contrast Improvements v1.2.5 by Hebgbs (@w/ :heart:)
+/* Contrast Improvements v1.2.6 by Hebgbs (@w/ :heart:)
    Black text and objects where it is otherwise difficult to see with brighter colours.
    
    This code must be the first import to be fully effective. */
 
-.tooltip, BUTTON:not(.outlined):not(.dark-red):not(.btn-default), .badge, .alert-actions .btn,
-.settings-panel .control-group:nth-child(2) .region-select:hover button,
-.is-local-bot-message *:not(A):not(.bot-tag), ::selection, .note textarea::selection, .clipboard-input-inner input::selection,
+.tooltip, BUTTON:not(.outlined), .badge, .alert-actions .btn, .settings-panel .control-group:nth-child(2) .region-select:hover BUTTON
+.theme-light .is-local-bot-message *:not(A):not(.bot-tag), ::selection, .note textarea::selection, .clipboard-input-inner input::selection,
 .change-log .changelog-added, .change-log .changelog-added-secondary, .change-log .changelog-improved,
 .guilds-wrapper .guilds .friends-online:hover, .channel-textarea-autocomplete-inner .active *,
 .search-popout .search-option:hover .answer, .search-popout .search-option.selected .answer,
 .search-popout .user:hover .display-username, .search-popout .user.selected .display-username,
 .react-datepicker__day:hover, .date-picker-hint .hint-value, .need-help-modal H1,
-.user-settings-modal .now-playing *, .user-settings-modal-keybinds-header *, DIV#voice-connection-popout HEADER,
+.user-settings-modal .now-playing *, .user-settings-modal-keybinds-header *, DIV#rtc-connection-popout HEADER,
 .user-settings-modal-connections-list .btn-delete:hover, #overlay-explanation, #overlay-explanation A, .change-nickname-warning,
 .Select-option.is-selected, .Select-menu .is-selected DIV .primary, .Select-menu .is-selected DIV .localized,
 .upload-drop-modal *, .new-messages-indicator, .popout-menu-item.invite *,
 DIV.messages-popout-wrap .messages-popout .message-group .action-buttons .jump-button:hover .text,
+/* Allow me to remark how much I hate it has to be this stupidly long selector. I hate it. */
 .flex-spacer.flex-vertical .comment .message:not(.mentioned) .body DIV.markup .mention:hover, .recent-mentions-popout .mention:hover,
 .quickswitcher .result.selected, DIV.search-results-wrap .action-buttons .jump-button:hover,
 DIV.chat .divider.divider-red SPAN, DIV.chat .jump-to-present-bar:hover BUTTON, .guild-settings-modal-emoji-header .btn-primary,
@@ -27,19 +27,19 @@ DIV.chat .divider.divider-red SPAN, DIV.chat .jump-to-present-bar:hover BUTTON, 
 #friends .friends-header .tab-bar.UNIQUE .tab-bar-item.selected DIV.badge{
     background-color: #000 !important;}
 
-.btn-confirm BUTTON, .user-settings-modal-connections-list .btn-delete,
+.btn-confirm BUTTON, .btn.btn-default, .user-settings-modal-connections-list .btn-delete,
 .form-actions .btn:not(.btn-primary), .webhook-actions .btn:not(.btn-primary):not(.btn-clear),
 .alert-actions .btn:not(.btn-primary), .modal-inner .button:not(.button-primary),
-.settings-panel .control-group:nth-child(2) .region-select:not(:hover) BUTTON{
+.ui-guild-nsfw .ui-button-contents, .settings-panel .control-group:nth-child(2) .region-select:not(:hover) BUTTON{
     color: #fff !important;}
 
 .is-local-bot-message A{
     color: #00b0f4 !important;}
 
 .ui-guild-nsfw DIV:not(.ui-button-contents){
-    text-shadow: 0px 0px 6px #000,
-                 0px 0px 6px #000,
-                 0px 0px 6px #000;}
+    text-shadow: 0px 0px 6px #932b2b,
+                 0px 0px 6px #932b2b,
+                 0px 0px 6px #932b2b;}
 
 .icon.icon-unread-arrow, .guild:first-child:hover .friends-icon:after,
 .guild:first-child.active .friends-icon:after, .channel .icon-friends:after,


### PR DESCRIPTION
I don't understand what was going on with the :not tokens but I decided to move `.btn-default` out from the black text block as an exemption and placed `.btn.btn-default` in the white text block. Don't understand what's breaking either; Chaining `:not` tokens shouldn't cause issues as anything which isn't _there_ should remain benign but it doesn't. Oh well.

Also sorry for not making a PR after I said it existed in Discord.